### PR TITLE
Mask API key in .env example

### DIFF
--- a/text.md
+++ b/text.md
@@ -1,7 +1,8 @@
 # Crie um arquivo `.env`
 
 ```
-OPENAI_API_KEY="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"
+# Make sure to hide this somewhere
+OPENAI_API_KEY="<your_api_key>"
 ```
 
 


### PR DESCRIPTION
Updated example in text.md to replace actual API key with a placeholder for security.